### PR TITLE
Update Dockerfile to work with ARM based systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.16.5-alpine3.13
 RUN \
   apk add --no-cache make git gcc g++ protobuf && \
   export GO111MODULE=on && \


### PR DESCRIPTION
The current version of the docker image does not work on Apple Silicon computers because it fails with the error `qemu: uncaught target signal 11 (Segmentation fault) - core dumped`. This can be fixed by basing the image upon an alpine version that supports ARM based systems.